### PR TITLE
worker actors for ChatServer

### DIFF
--- a/src/main/scala/org/sandbox/chat/BroadcastManager.scala
+++ b/src/main/scala/org/sandbox/chat/BroadcastManager.scala
@@ -1,0 +1,29 @@
+package org.sandbox.chat
+
+import scala.concurrent.duration.DurationInt
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.Props
+import akka.pattern.{ ask, pipe }
+import akka.util.Timeout
+
+class BroadcastManager(participantAdmin: ActorRef) extends Actor {
+  import ParticipantAdministrator._
+  import ChatServer._
+
+  import context.dispatcher
+  implicit val timeout = Timeout(1 second)
+
+  def receive: Receive = {
+    case broadcast: Broadcast =>
+      val allParticipants = (participantAdmin ? GetAllParticipants).mapTo[AllParticipants]
+      allParticipants onSuccess {
+        case AllParticipants(participants) => participants foreach(_.who ! broadcast)
+      }
+  }
+}
+
+object BroadcastManager {
+  def props(participantAdmin: ActorRef): Props =
+    Props(new BroadcastManager(participantAdmin))
+}

--- a/src/main/scala/org/sandbox/chat/ChatServer.scala
+++ b/src/main/scala/org/sandbox/chat/ChatServer.scala
@@ -8,47 +8,66 @@ import org.sandbox.chat.http.HttpChatService
 import org.sandbox.chat.http.HttpChatServiceActionsImpl
 import org.sandbox.chat.sse.SseChatService
 
+import ParticipantAdministrator.AllParticipants
+import ParticipantAdministrator.GetAllParticipants
+import ParticipantAdministrator.IsJoined
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.ActorRef
 import akka.actor.Props
 import akka.actor.actorRef2Scala
 import akka.event.LoggingReceive
+import akka.pattern.ask
+import akka.pattern.pipe
+import akka.util.Timeout
 
 class ChatServer extends Actor with ServiceActor with ActorLogging {
   import ChatServer._
+  import ParticipantAdministrator._
   import context.dispatcher
 
   val settings = Settings(context.system)
 
   val chatMsgPublisher = context.actorOf(Props[ChatMsgPublisher])
+  val participantAdmin = context.actorOf(ParticipantAdministrator.props())
+  val broadcastManager = context.actorOf(BroadcastManager.props(participantAdmin))
+
   val httpChatService = createHttpService
   val sseChatService = createSseService
 
-  var participants: Set[Participant] = Set.empty
-
-  private def ackAndPublish(msg: ChatServerMsg with Ackable) = {
+  private def publish(msg: ChatServerMsg) =
     chatMsgPublisher ! msg
-    sender ! Ack(msg)
-  }
+
+  implicit val timeout = Timeout(1 second)
 
   private def chatReceive: Receive = {
-    case join@Join(who) =>
-      participants += who
-      ackAndPublish(join)
-    case leave@Leave(who) =>
-      participants -= who
-      ackAndPublish(leave)
-    case contribution@Contribution(author@Participant(_,name), msg) if participants contains author =>
-      self ! Broadcast(name, msg)
-      ackAndPublish(contribution)
+    case msg: ParticipantAdminMsg =>
+      val ack = (participantAdmin ? msg).mapTo[Ack]
+      ack.onSuccess { case Ack(msg) => publish(msg) }
+      ack pipeTo sender
+    case contribution@Contribution(author@Participant(_,name), msg) =>
+      val requestor = sender
+      val isJoined = (participantAdmin ? IsJoined(author)).mapTo[IsJoined]
+      isJoined onSuccess {
+        case IsJoined(_, isJoined) if isJoined =>
+          requestor ! Ack(contribution)
+          self ! Broadcast(name, msg)
+          publish(contribution)
+      }
     case broadcast: Broadcast =>
-      participants foreach(_.who ! broadcast)
-      chatMsgPublisher ! broadcast
+      broadcastManager ! broadcast
+      publish(broadcast)
     case shutdown: Shutdown =>
-      ackAndPublish(shutdown.copy(participants = participants))
-      log.info(s"ChatServer ${self.path.name} to shutdown in ${500 millis} ...")
-      context.system.scheduler.scheduleOnce(500 millis)(context.system.shutdown)
+      val requestor = sender
+      val allParticipants = (participantAdmin ? GetAllParticipants).mapTo[AllParticipants]
+      allParticipants onSuccess {
+        case AllParticipants(participants) =>
+          val msg = shutdown.copy(participants = participants)
+          publish(msg)
+          requestor ! Ack(msg)
+          log.info(s"ChatServer ${self.path.name} to shutdown in ${500 millis} ...")
+          context.system.scheduler.scheduleOnce(500 millis)(context.system.shutdown)
+      }
   }
 
   override def receive: Receive = LoggingReceive {
@@ -85,11 +104,12 @@ object ChatServer {
 
   case class Participant(who: ActorRef, name: String)
 
-  trait Ackable
+  trait ParticipantAdminMsg
 
   sealed trait ChatServerMsg
-  case class Join(who: Participant) extends ChatServerMsg with Ackable
-  case class Leave(who: Participant) extends ChatServerMsg with Ackable
+  trait Ackable extends ChatServerMsg
+  case class Join(who: Participant) extends ChatServerMsg with Ackable with ParticipantAdminMsg
+  case class Leave(who: Participant) extends ChatServerMsg with Ackable with ParticipantAdminMsg
   case class Contribution(author: Participant, msg: String) extends ChatServerMsg with Ackable
   case class Broadcast(authorName: String, msg: String, when: Date  = new Date) extends ChatServerMsg
   case class Shutdown(participants: Set[Participant] = Set()) extends ChatServerMsg with Ackable

--- a/src/main/scala/org/sandbox/chat/ParticipantAdministrator.scala
+++ b/src/main/scala/org/sandbox/chat/ParticipantAdministrator.scala
@@ -1,0 +1,39 @@
+package org.sandbox.chat
+
+import ChatServer.Participant
+import akka.actor.Actor
+import akka.actor.Props
+
+class ParticipantAdministrator extends Actor {
+  import ParticipantAdministrator._
+  import ChatServer._
+
+  var participants: Set[Participant] = Set.empty
+
+  def receive: Receive = update orElse query
+
+  private def update: Receive = {
+    case join@Join(who) =>
+      participants += who
+      sender ! Ack(join)
+    case leave@Leave(who) =>
+      participants -= who
+      sender ! Ack(leave)
+  }
+
+  private def query: Receive = {
+    case isJoined@IsJoined(who, _) =>
+      sender ! isJoined.copy(joined = participants.contains(who))
+    case GetAllParticipants =>
+      sender ! AllParticipants(participants)
+  }
+}
+
+object ParticipantAdministrator {
+  def props(): Props = Props[ParticipantAdministrator]
+
+  sealed trait ParticipantAdministratorMsg
+  case class IsJoined(who: Participant, joined: Boolean = false) extends ParticipantAdministratorMsg
+  case object GetAllParticipants extends ParticipantAdministratorMsg
+  case class AllParticipants(participants: Set[Participant]) extends ParticipantAdministratorMsg
+}

--- a/src/main/scala/org/sandbox/chat/http/HttpChatApp.scala
+++ b/src/main/scala/org/sandbox/chat/http/HttpChatApp.scala
@@ -1,6 +1,5 @@
 package org.sandbox.chat.http
 
-import org.sandbox.chat.ChatMsgPublisher
 import org.sandbox.chat.ChatServer
 import org.sandbox.chat.ServiceActor
 import org.sandbox.chat.Settings
@@ -20,8 +19,6 @@ trait HttpChat {
 //    system.shutdown
 //    system.awaitTermination
 //  }
-
-  val chatMsgPublisher: ActorRef = system.actorOf(Props[ChatMsgPublisher])
 
   val chatServer = system.actorOf(ChatServer.props, "ChuckNorris")
   waitForRunningService(chatServer)

--- a/src/main/scala/org/sandbox/chat/http/HttpChatClient.scala
+++ b/src/main/scala/org/sandbox/chat/http/HttpChatClient.scala
@@ -24,6 +24,7 @@ class HttpChatClient private(chatServer: ActorRef) extends Actor {
   def receive: Actor.Receive = LoggingReceive {
     case broadcast: Broadcast if sender == chatServer =>
       broadcasts = broadcasts :+ broadcast
+    case broadcast: Broadcast => // ignore
     case GetBroadcasts =>
       sender ! Broadcasts(broadcasts)
       broadcasts = Seq.empty


### PR DESCRIPTION
ChatServer to delegate work to child actors
client polling not working: to avoid an infinite loop for Broadcast messages HttpChatClient now does not pipe them further anymore.
Question: Do we need polling at all? If so we might have a better mechanism anyway, like storing the Date of last polled message, perhaps in ParticipantAdminstrator or some new PollingAdministrator actor or so.
